### PR TITLE
Fix stereo audio tail noise caused by off-by-one in sample bounds check

### DIFF
--- a/src/VorbisPluginEncoder.c
+++ b/src/VorbisPluginEncoder.c
@@ -140,8 +140,8 @@ static int32_t write_all_pcm_data_using_on_write_callback(
     long j = 0;
     while (!eos) {
         long to_read = samples_to_write;
-        if (j + to_read > samples_length) {
-            to_read = samples_length - j;
+        if (j + to_read * channels > samples_length) {
+            to_read = (samples_length - j) / channels;
         }
 
         if (to_read == 0) {


### PR DESCRIPTION
## Problem

While generating Vorbis files from AudioClip, I ran into two issues:

- Some encoded files had a click/pop noise at the very end
- The encoded duration was consistently slightly longer than the original

I asked Claude Code to look into the encoder source, and it found the following bug.

## Root Cause

In `VorbisPluginEncoder.c`, the bounds check for the last chunk compared `j` (an index into the interleaved sample array) against `samples_length` using `to_read` as if it were a frame count:

    if (j + to_read > samples_length) {
        to_read = samples_length - j;
    }

`samples_length` is the total number of interleaved samples (frames x channels), but `to_read` is a frame count. For stereo audio, this means the check allows one extra frame to be read beyond the end of the buffer, producing garbage data at the tail.

## Fix

Multiply `to_read` by `channels` before comparing, and divide when computing the remainder:

    if (j + to_read * channels > samples_length) {
        to_read = (samples_length - j) / channels;
    }

## Verified

After applying this fix and rebuilding the DLL, the tail noise no longer occurs and the encoded duration is now correct.
